### PR TITLE
Feature/add ECS Exec support to OWUI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 # use build args in the docker build command with --build-arg="BUILDARG=true"
 ARG USE_CUDA=false
 ARG USE_OLLAMA=false
+ARG ENABLE_ECS_EXEC=false
 # Tested with cu117 for CUDA 11 and cu121 for CUDA 12 (default)
 ARG USE_CUDA_VER=cu128
 # any sentence transformer model; models to use can be found at https://huggingface.co/models?library=sentence-transformers
@@ -45,6 +46,7 @@ ARG USE_OLLAMA
 ARG USE_CUDA_VER
 ARG USE_EMBEDDING_MODEL
 ARG USE_RERANKING_MODEL
+ARG ENABLE_ECS_EXEC
 ARG UID
 ARG GID
 
@@ -140,6 +142,30 @@ RUN if [ "$USE_OLLAMA" = "true" ]; then \
     rm -rf aws awscliv2.zip && \
     # cleanup
     rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Install Amazon SSM Agent for ECS Exec (configurable via build arg)
+RUN if [ "$ENABLE_ECS_EXEC" = "true" ]; then \
+    echo "Installing Amazon SSM Agent for ECS Exec support..." && \
+    # Install dependencies for SSM agent
+    apt-get update && \
+    apt-get install -y --no-install-recommends wget ca-certificates && \
+    # Download and install SSM agent for the correct architecture
+    ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        wget -q "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb" -O /tmp/amazon-ssm-agent.deb; \
+    elif [ "$ARCH" = "arm64" ]; then \
+        wget -q "https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_arm64/amazon-ssm-agent.deb" -O /tmp/amazon-ssm-agent.deb; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    dpkg -i /tmp/amazon-ssm-agent.deb && \
+    rm -f /tmp/amazon-ssm-agent.deb && \
+    # Cleanup
+    rm -rf /var/lib/apt/lists/* && \
+    echo "SSM Agent installation complete for architecture: $ARCH"; \
+    else \
+    echo "Skipping SSM Agent installation (ENABLE_ECS_EXEC=false)"; \
     fi
 
 # install python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # use build args in the docker build command with --build-arg="BUILDARG=true"
 ARG USE_CUDA=false
 ARG USE_OLLAMA=false
-ARG ENABLE_ECS_EXEC=false
+ARG ENABLE_ECS_EXEC=true
 # Tested with cu117 for CUDA 11 and cu121 for CUDA 12 (default)
 ARG USE_CUDA_VER=cu128
 # any sentence transformer model; models to use can be found at https://huggingface.co/models?library=sentence-transformers

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -25,6 +25,14 @@ else
     echo "❌ Certificate NOT found in either location"
 fi
 
+# Start SSM Agent for ECS Exec if enabled
+if [ "$ENABLE_ECS_EXEC" = "true" ]; then
+    echo "INFO: Starting SSM Agent for ECS Exec support..."
+    # Start SSM Agent in the background
+    /usr/bin/amazon-ssm-agent &
+    echo "INFO: SSM Agent started successfully."
+fi
+
 echo "INFO: Checking database authentication method..."
 
 # Define the application entrypoint module path


### PR DESCRIPTION
**ECS EXEC support in OWUI works. Helps debug connectivity issues to BAG.**

# Outstanding issues:

- Fix OWUI build error. Supposedly a transient issue from a 3rd party package that should go away by itself in 24h.
_GPG error: http://deb.debian.org/debian bookworm InRelease: At least one invalid signature was encountered._

- Fix this hard-coded value
`ENABLE_ECS_EXEC=true`
Should pick it up from config yml file, although that was not working properly.

- Prob can remove this code from backend/docker-entrypoint.sh
```
# Start SSM Agent for ECS Exec if enabled
if [ "$ENABLE_ECS_EXEC" = "true" ]; then
    echo "INFO: Starting SSM Agent for ECS Exec support..."
    # Start SSM Agent in the background
    /usr/bin/amazon-ssm-agent &
    echo "INFO: SSM Agent started successfully."
fi
```

