### PR TITLE
fix(logging): sweep all DIAG-tagged content logging (TPAI S03, m1 Phase B(i), E3)

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1434,7 +1434,6 @@ async def chat_completion(
         )
 
     except Exception as e:
-        log.warning(f"[TPAI-DIAG] Error processing chat payload: {e}")
         log.debug(f"Error processing chat payload: {e}")
         if metadata.get("chat_id") and metadata.get("message_id"):
             # Update the chat message with the error
@@ -1452,15 +1451,12 @@ async def chat_completion(
         )
 
     try:
-        log.warning(f"[TPAI-DIAG] Calling chat_completion_handler: model={form_data.get('model')} user={user.id} role={user.role}")
         response = await chat_completion_handler(request, form_data, user)
-        log.warning(f"[TPAI-DIAG] chat_completion_handler returned: type={type(response).__name__}")
 
         return await process_chat_response(
             request, response, form_data, user, metadata, model, events, tasks
         )
     except Exception as e:
-        log.warning(f"[TPAI-DIAG] Error in chat completion: {e}")
         log.debug(f"Error in chat completion: {e}")
         if metadata.get("chat_id") and metadata.get("message_id"):
             # Update the chat message with the error

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -828,7 +828,12 @@ async def generate_chat_completion(
 
     payload = json.dumps(payload)
 
-    log.warning(f"[TPAI-DIAG] chat/completions → URL={request_url} model={form_data.get('model')} user={user.id} role={user.role} stream={form_data.get('stream')}")
+    # Metadata only — request/response bodies are never logged (TPAI
+    # external-content decision E3; the acceptance check asserts no
+    # content fields exist in these logs).
+    log.info(
+        f"chat/completions request: url={request_url} model={form_data.get('model')} user={user.id} stream={form_data.get('stream')}"
+    )
 
     r = None
     session = None
@@ -848,7 +853,9 @@ async def generate_chat_completion(
             ssl=AIOHTTP_CLIENT_SESSION_SSL,
         )
 
-        log.warning(f"[TPAI-DIAG] BAG response: status={r.status} content_type={r.headers.get('Content-Type', 'N/A')}")
+        log.info(
+            f"chat/completions response: status={r.status} content_type={r.headers.get('Content-Type', 'N/A')}"
+        )
 
         # Check if response is SSE
         if "text/event-stream" in r.headers.get("Content-Type", ""):
@@ -868,11 +875,11 @@ async def generate_chat_completion(
                 log.error(e)
                 response = await r.text()
 
-            log.warning(f"[TPAI-DIAG] BAG non-stream response: {str(response)[:500]}")
             r.raise_for_status()
             return response
     except Exception as e:
-        log.exception(f"[TPAI-DIAG] chat/completions exception: {e}")
+        # Exception type only — str(e) can echo payload fragments (E3).
+        log.exception(f"chat/completions request failed ({type(e).__name__})")
 
         detail = None
         if isinstance(response, dict):

--- a/backend/open_webui/utils/chat.py
+++ b/backend/open_webui/utils/chat.py
@@ -191,8 +191,6 @@ async def generate_chat_completion(
 
     model = models[model_id]
 
-    log.warning(f"[TPAI-DIAG] generate_chat_completion: model_id={model_id} owned_by={model.get('owned_by')} pipe={model.get('pipe')} direct={getattr(request.state, 'direct', False)} bypass_filter={bypass_filter} user_role={user.role}")
-
     if getattr(request.state, "direct", False):
         return await generate_direct_chat_completion(
             request, form_data, user=user, models=models
@@ -203,7 +201,9 @@ async def generate_chat_completion(
             try:
                 check_model_access(user, model)
             except Exception as e:
-                log.warning(f"[TPAI-DIAG] Model access denied: model_id={model_id} user={user.id} error={e}")
+                log.warning(
+                    f"Model access denied: model_id={model_id} user={user.id} ({type(e).__name__})"
+                )
                 raise e
 
         if model.get("owned_by") == "arena":


### PR DESCRIPTION
## Plan

- Program: TPAI `plans/external-content/ROADMAP.md` — **ADR-1 condition 2**, execution decision **E3** (delete body/content logging, no debug flag, no break-glass)
- Milestone: `plans/external-content/m1-substrate/plan.md` — **Phase B(i)** ("Also OWUI-side: the fork carries its own DIAG lines that log gateway responses from inside OWUI — same PHI sink once tool content flows, same treatment")
- Session: `plans/external-content/SESSIONS.md` — **S03**

## What changed — all 10 fork-local DIAG lines

| File | Line (pre) | Disposition |
|---|---|---|
| `backend/open_webui/main.py` | 1437 | deleted — duplicated the upstream `log.debug` directly beneath it |
| `backend/open_webui/main.py` | 1455, 1457 | deleted — per-request chatter (handler call/return) |
| `backend/open_webui/main.py` | 1463 | deleted — duplicated the upstream `log.debug` beneath it |
| `backend/open_webui/routers/openai.py` | 831 | kept as metadata-only `log.info` (url, model, user id, stream) — no role, no DIAG tag |
| `backend/open_webui/routers/openai.py` | 851 | kept as metadata-only `log.info` (status, content-type) |
| `backend/open_webui/routers/openai.py` | 871 | **deleted — the 500-char response-body sample (the PHI sink)** |
| `backend/open_webui/routers/openai.py` | 875 | `log.exception` reduced to exception type name — `str(e)` can echo payload fragments |
| `backend/open_webui/utils/chat.py` | 194 | deleted — per-generation chatter |
| `backend/open_webui/utils/chat.py` | 206 | access-denied warning kept; exception interpolation reduced to type name |

## Verification

- Clean-sweep grep across the repo (`*.py`, `*.ts`, `*.js`, `*.svelte`, excluding node_modules): `grep -rn "TPAI-DIAG"` → **0 occurrences**
- `python -m py_compile` on all three files: OK
- `black --check`: unchanged (matches the Format Backend CI gate)

The runtime no-content assertion lives in the bedrock-gateway test suite and the Phase F acceptance-harness standing negative control (this repo has no backend-test CI). Companion PRs: clavesec/bedrock-access-gateway#3 (gateway-side E3) + TPAI main-repo submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)