### PR TITLE
ci: pin black + reformat — make the Format Backend gate green and deterministic

### DIFF
--- a/.github/workflows/format-backend.yaml
+++ b/.github/workflows/format-backend.yaml
@@ -40,7 +40,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black
+          # Pinned: the gate must check this repo's formatting, not track
+          # black's latest style. The tree is formatted with exactly this
+          # version — bump the pin and reformat in the same commit.
+          pip install black==25.12.0
 
       - name: Format backend
         run: npm run format:backend

--- a/backend/open_webui/internal/db.py
+++ b/backend/open_webui/internal/db.py
@@ -67,95 +67,115 @@ def mark_existing_migrations_complete(db):
         from datetime import datetime
 
         # Check if core tables exist (auth, user, chat, tag)
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT COUNT(*) FROM pg_tables
             WHERE schemaname = 'public'
             AND tablename IN ('auth', 'user', 'chat', 'tag')
-        """)
+        """
+        )
         core_tables_count = cursor.fetchone()[0]
 
         if core_tables_count < 4:
-            print("🗄️ PRE_MIGRATION: Core tables don't exist yet, migrations will create them")
-            log.info("🗄️ PRE_MIGRATION: Core tables don't exist yet, migrations will create them")
+            print(
+                "🗄️ PRE_MIGRATION: Core tables don't exist yet, migrations will create them"
+            )
+            log.info(
+                "🗄️ PRE_MIGRATION: Core tables don't exist yet, migrations will create them"
+            )
             return
 
-        print(f"🗄️ PRE_MIGRATION: Found {core_tables_count} core tables, checking migration tracking...")
-        log.info(f"🗄️ PRE_MIGRATION: Found {core_tables_count} core tables, checking migration tracking...")
+        print(
+            f"🗄️ PRE_MIGRATION: Found {core_tables_count} core tables, checking migration tracking..."
+        )
+        log.info(
+            f"🗄️ PRE_MIGRATION: Found {core_tables_count} core tables, checking migration tracking..."
+        )
 
         # Check if migratehistory table exists
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE schemaname = 'public' AND tablename = 'migratehistory'
             )
-        """)
+        """
+        )
         migrate_table_exists = cursor.fetchone()[0]
 
         if not migrate_table_exists:
             print("🗄️ PRE_MIGRATION: Creating migratehistory table...")
             log.info("🗄️ PRE_MIGRATION: Creating migratehistory table...")
-            db.execute_sql("""
+            db.execute_sql(
+                """
                 CREATE TABLE migratehistory (
                     id SERIAL PRIMARY KEY,
                     name VARCHAR(255) NOT NULL,
                     migrated_at TIMESTAMP NOT NULL
                 )
-            """)
+            """
+            )
 
         # Check which migrations are already recorded
         cursor = db.execute_sql("SELECT name FROM migratehistory ORDER BY name")
         recorded_migrations = [row[0] for row in cursor.fetchall()]
         print(f"🗄️ PRE_MIGRATION: Currently recorded migrations: {recorded_migrations}")
-        log.info(f"🗄️ PRE_MIGRATION: Currently recorded migrations: {recorded_migrations}")
+        log.info(
+            f"🗄️ PRE_MIGRATION: Currently recorded migrations: {recorded_migrations}"
+        )
 
         # List of migrations that should be marked complete if tables exist
         # (001-018 are the migrations that existed before our fix)
         expected_migrations = [
-            '001_initial_schema',
-            '002_add_local_sharing',
-            '003_add_auth_api_key',
-            '004_add_archived',
-            '005_add_updated_at',
-            '006_migrate_timestamps_and_charfields',
-            '007_add_user_last_active_at',
-            '008_add_memory',
-            '009_add_models',
-            '010_migrate_modelfiles_to_models',
-            '011_add_user_settings',
-            '012_add_tools',
-            '013_add_user_info',
-            '014_add_files',
-            '015_add_functions',
-            '016_add_valves_and_is_active',
-            '017_add_user_oauth_sub',
-            '018_add_function_is_global',
+            "001_initial_schema",
+            "002_add_local_sharing",
+            "003_add_auth_api_key",
+            "004_add_archived",
+            "005_add_updated_at",
+            "006_migrate_timestamps_and_charfields",
+            "007_add_user_last_active_at",
+            "008_add_memory",
+            "009_add_models",
+            "010_migrate_modelfiles_to_models",
+            "011_add_user_settings",
+            "012_add_tools",
+            "013_add_user_info",
+            "014_add_files",
+            "015_add_functions",
+            "016_add_valves_and_is_active",
+            "017_add_user_oauth_sub",
+            "018_add_function_is_global",
         ]
 
         # Delete old incorrect migration names that don't match actual files
         old_incorrect_names = [
-            '004_add_chat_sharing',
-            '005_add_user_info',
-            '006_add_chat_tags',
-            '007_add_metadata_to_user',
-            '008_add_model_filter_config',
-            '009_add_model_config',
-            '010_add_tags_table_and_chat_tags',
-            '011_add_user_last_active_at',
-            '012_add_prompt',
-            '013_add_archived_flag_to_chat',
-            '014_add_local_sharing_to_chat',
-            '015_add_chat_metadata',
-            '016_add_file_model',
-            '017_add_ollama_model_details',
-            '018_add_modelfile_model_metadata',
+            "004_add_chat_sharing",
+            "005_add_user_info",
+            "006_add_chat_tags",
+            "007_add_metadata_to_user",
+            "008_add_model_filter_config",
+            "009_add_model_config",
+            "010_add_tags_table_and_chat_tags",
+            "011_add_user_last_active_at",
+            "012_add_prompt",
+            "013_add_archived_flag_to_chat",
+            "014_add_local_sharing_to_chat",
+            "015_add_chat_metadata",
+            "016_add_file_model",
+            "017_add_ollama_model_details",
+            "018_add_modelfile_model_metadata",
         ]
 
         for old_name in old_incorrect_names:
             if old_name in recorded_migrations:
                 print(f"🗄️ PRE_MIGRATION: Removing incorrect migration name: {old_name}")
-                log.info(f"🗄️ PRE_MIGRATION: Removing incorrect migration name: {old_name}")
+                log.info(
+                    f"🗄️ PRE_MIGRATION: Removing incorrect migration name: {old_name}"
+                )
                 # Use ? as placeholder for SQLite/Peewee compatibility, it gets auto-converted for PostgreSQL
-                cursor = db.execute_sql("DELETE FROM migratehistory WHERE name = ?", (old_name,))
+                cursor = db.execute_sql(
+                    "DELETE FROM migratehistory WHERE name = ?", (old_name,)
+                )
                 cursor.close()
 
         print("🗄️ PRE_MIGRATION: ✅ Cleaned up old incorrect migration names")
@@ -170,13 +190,17 @@ def mark_existing_migrations_complete(db):
                 log.info(f"🗄️ PRE_MIGRATION: Marking {migration_name} as complete...")
                 db.execute_sql(
                     "INSERT INTO migratehistory (name, migrated_at) VALUES (%s, %s)",
-                    (migration_name, now)
+                    (migration_name, now),
                 )
                 migrations_marked += 1
 
         if migrations_marked > 0:
-            print(f"🗄️ PRE_MIGRATION: ✅ Marked {migrations_marked} migrations as complete")
-            log.info(f"🗄️ PRE_MIGRATION: ✅ Marked {migrations_marked} migrations as complete")
+            print(
+                f"🗄️ PRE_MIGRATION: ✅ Marked {migrations_marked} migrations as complete"
+            )
+            log.info(
+                f"🗄️ PRE_MIGRATION: ✅ Marked {migrations_marked} migrations as complete"
+            )
         else:
             print("🗄️ PRE_MIGRATION: All expected migrations already recorded")
             log.info("🗄️ PRE_MIGRATION: All expected migrations already recorded")
@@ -192,12 +216,14 @@ def fix_tag_table_schema(db):
     """Fix tag table schema issues before running migrations."""
     try:
         # Check if tag table exists
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE schemaname = 'public' AND tablename = 'tag'
             )
-        """)
+        """
+        )
         tag_exists = cursor.fetchone()[0]
 
         if not tag_exists:
@@ -209,37 +235,47 @@ def fix_tag_table_schema(db):
         log.info("🗄️ PRE_MIGRATION: Tag table exists, checking for schema issues...")
 
         # Check for duplicate (id, user_id) pairs
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT id, user_id, COUNT(*) as cnt
             FROM tag
             GROUP BY id, user_id
             HAVING COUNT(*) > 1
-        """)
+        """
+        )
         duplicates = cursor.fetchall()
 
         if duplicates:
-            print(f"🗄️ PRE_MIGRATION: Found {len(duplicates)} duplicate (id, user_id) pairs, cleaning up...")
-            log.warning(f"🗄️ PRE_MIGRATION: Found {len(duplicates)} duplicate (id, user_id) pairs, cleaning up...")
+            print(
+                f"🗄️ PRE_MIGRATION: Found {len(duplicates)} duplicate (id, user_id) pairs, cleaning up..."
+            )
+            log.warning(
+                f"🗄️ PRE_MIGRATION: Found {len(duplicates)} duplicate (id, user_id) pairs, cleaning up..."
+            )
 
             # Delete duplicates, keeping first occurrence
-            db.execute_sql("""
+            db.execute_sql(
+                """
                 DELETE FROM tag
                 WHERE ctid NOT IN (
                     SELECT MIN(ctid)
                     FROM tag
                     GROUP BY id, user_id
                 )
-            """)
+            """
+            )
             print(f"🗄️ PRE_MIGRATION: ✅ Cleaned up duplicate records")
             log.info(f"🗄️ PRE_MIGRATION: ✅ Cleaned up duplicate records")
 
         # Check current primary key
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT conname, pg_get_constraintdef(c.oid)
             FROM pg_constraint c
             WHERE c.conrelid = 'tag'::regclass
               AND c.contype = 'p'
-        """)
+        """
+        )
         pk_info = cursor.fetchone()
 
         if pk_info:
@@ -248,9 +284,11 @@ def fix_tag_table_schema(db):
             log.info(f"🗄️ PRE_MIGRATION: Current primary key: {pk_name} - {pk_def}")
 
             # Check if it's already a composite key
-            if '(id, user_id)' in pk_def or '(user_id, id)' in pk_def:
+            if "(id, user_id)" in pk_def or "(user_id, id)" in pk_def:
                 print("🗄️ PRE_MIGRATION: ✅ Tag table already has composite primary key")
-                log.info("🗄️ PRE_MIGRATION: ✅ Tag table already has composite primary key")
+                log.info(
+                    "🗄️ PRE_MIGRATION: ✅ Tag table already has composite primary key"
+                )
                 return
 
             # Drop old primary key
@@ -259,26 +297,33 @@ def fix_tag_table_schema(db):
             db.execute_sql(f'ALTER TABLE tag DROP CONSTRAINT "{pk_name}"')
 
         # Drop conflicting unique constraints and indexes
-        for constraint_name in ['uq_id_user_id', 'tag_id']:
-            cursor = db.execute_sql("""
+        for constraint_name in ["uq_id_user_id", "tag_id"]:
+            cursor = db.execute_sql(
+                """
                 SELECT 1 FROM pg_constraint
                 WHERE conrelid = 'tag'::regclass
                   AND contype = 'u'
                   AND conname = %s
-            """, (constraint_name,))
+            """,
+                (constraint_name,),
+            )
             if cursor.fetchone():
                 print(f"🗄️ PRE_MIGRATION: Dropping unique constraint: {constraint_name}")
-                log.info(f"🗄️ PRE_MIGRATION: Dropping unique constraint: {constraint_name}")
+                log.info(
+                    f"🗄️ PRE_MIGRATION: Dropping unique constraint: {constraint_name}"
+                )
                 db.execute_sql(f'ALTER TABLE tag DROP CONSTRAINT "{constraint_name}"')
 
         # Drop unique indexes
-        for index_name in ['tag_id', 'uq_id_user_id']:
+        for index_name in ["tag_id", "uq_id_user_id"]:
             db.execute_sql(f'DROP INDEX IF EXISTS "{index_name}"')
 
         # Create composite primary key
         print("🗄️ PRE_MIGRATION: Creating composite primary key (id, user_id)...")
         log.info("🗄️ PRE_MIGRATION: Creating composite primary key (id, user_id)...")
-        db.execute_sql('ALTER TABLE tag ADD CONSTRAINT pk_id_user_id PRIMARY KEY (id, user_id)')
+        db.execute_sql(
+            "ALTER TABLE tag ADD CONSTRAINT pk_id_user_id PRIMARY KEY (id, user_id)"
+        )
         print("🗄️ PRE_MIGRATION: ✅ Created composite primary key")
         log.info("🗄️ PRE_MIGRATION: ✅ Created composite primary key")
 
@@ -299,12 +344,14 @@ def fix_alembic_config_table(db):
     """
     try:
         # Check if config table exists
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE schemaname = 'public' AND tablename = 'config'
             )
-        """)
+        """
+        )
         config_exists = cursor.fetchone()[0]
 
         if config_exists:
@@ -315,7 +362,8 @@ def fix_alembic_config_table(db):
             log.warning("🗄️ PRE_MIGRATION: Config table missing! Recreating...")
 
             # Recreate config table (from migration ca81bd47c050_add_config_table.py)
-            db.execute_sql("""
+            db.execute_sql(
+                """
                 CREATE TABLE config (
                     id SERIAL PRIMARY KEY,
                     data JSON NOT NULL,
@@ -323,34 +371,45 @@ def fix_alembic_config_table(db):
                     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
-            """)
+            """
+            )
             print("🗄️ PRE_MIGRATION: ✅ Recreated config table")
             log.info("🗄️ PRE_MIGRATION: ✅ Recreated config table")
 
         # Check if alembic_version table exists
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE schemaname = 'public' AND tablename = 'alembic_version'
             )
-        """)
+        """
+        )
         alembic_version_exists = cursor.fetchone()[0]
 
         if alembic_version_exists:
             # Check for bad migration 743f9468c8b1
-            cursor = db.execute_sql("""
+            cursor = db.execute_sql(
+                """
                 SELECT version_num FROM alembic_version
                 WHERE version_num = '743f9468c8b1'
-            """)
+            """
+            )
             bad_migration = cursor.fetchone()
 
             if bad_migration:
-                print("🗄️ PRE_MIGRATION: Removing bad migration 743f9468c8b1 from alembic_version...")
-                log.warning("🗄️ PRE_MIGRATION: Removing bad migration 743f9468c8b1 from alembic_version...")
-                db.execute_sql("""
+                print(
+                    "🗄️ PRE_MIGRATION: Removing bad migration 743f9468c8b1 from alembic_version..."
+                )
+                log.warning(
+                    "🗄️ PRE_MIGRATION: Removing bad migration 743f9468c8b1 from alembic_version..."
+                )
+                db.execute_sql(
+                    """
                     DELETE FROM alembic_version
                     WHERE version_num = '743f9468c8b1'
-                """)
+                """
+                )
                 print("🗄️ PRE_MIGRATION: ✅ Removed bad migration from history")
                 log.info("🗄️ PRE_MIGRATION: ✅ Removed bad migration from history")
 
@@ -370,12 +429,14 @@ def fix_missing_function_table(db):
     table doesn't exist. This function creates the table if needed.
     """
     try:
-        cursor = db.execute_sql("""
+        cursor = db.execute_sql(
+            """
             SELECT EXISTS (
                 SELECT FROM pg_tables
                 WHERE schemaname = 'public' AND tablename = 'function'
             )
-        """)
+        """
+        )
         function_exists = cursor.fetchone()[0]
 
         if function_exists:
@@ -387,7 +448,8 @@ def fix_missing_function_table(db):
         log.warning("🗄️ PRE_MIGRATION: Function table missing! Creating...")
 
         # Create function table (schema from 015_add_functions.py and 7e5b5dc7342b_init.py)
-        db.execute_sql("""
+        db.execute_sql(
+            """
             CREATE TABLE function (
                 id TEXT PRIMARY KEY,
                 user_id TEXT,
@@ -401,7 +463,8 @@ def fix_missing_function_table(db):
                 updated_at BIGINT,
                 created_at BIGINT
             )
-        """)
+        """
+        )
         print("🗄️ PRE_MIGRATION: ✅ Created function table")
         log.info("🗄️ PRE_MIGRATION: ✅ Created function table")
 
@@ -417,8 +480,12 @@ def fix_missing_function_table(db):
 def handle_peewee_migration(DATABASE_URL):
     # Temporary skip for manual database fix
     if os.environ.get("SKIP_PEEWEE_MIGRATIONS") == "true":
-        print("🗄️ DB_MIGRATION: ⚠️  SKIPPING Peewee migrations (SKIP_PEEWEE_MIGRATIONS=true)")
-        log.warning("🗄️ DB_MIGRATION: ⚠️  SKIPPING Peewee migrations (SKIP_PEEWEE_MIGRATIONS=true)")
+        print(
+            "🗄️ DB_MIGRATION: ⚠️  SKIPPING Peewee migrations (SKIP_PEEWEE_MIGRATIONS=true)"
+        )
+        log.warning(
+            "🗄️ DB_MIGRATION: ⚠️  SKIPPING Peewee migrations (SKIP_PEEWEE_MIGRATIONS=true)"
+        )
         return
 
     db = None

--- a/backend/open_webui/internal/wrappers.py
+++ b/backend/open_webui/internal/wrappers.py
@@ -130,7 +130,9 @@ def _augment_postgres_url_with_iam_and_ssl(db_url: str) -> str:
 
     # Debug SSL environment variables
     log.debug(f"SSL ENV: PG_SSLMODE={PG_SSLMODE}, PG_SSLROOTCERT={PG_SSLROOTCERT}")
-    log.debug(f"IAM ENV: ENABLE_AWS_RDS_IAM={ENABLE_AWS_RDS_IAM}, AWS_REGION={AWS_REGION}")
+    log.debug(
+        f"IAM ENV: ENABLE_AWS_RDS_IAM={ENABLE_AWS_RDS_IAM}, AWS_REGION={AWS_REGION}"
+    )
 
     try:
         from urllib.parse import urlparse, quote
@@ -193,7 +195,9 @@ def register_connection(db_url):
         Exception: If connection fails
     """
     # SECURITY: Only log URL prefix to avoid exposing credentials
-    log.info(f"DB_CONNECT: Starting register_connection with URL prefix: {db_url[:50]}...")
+    log.info(
+        f"DB_CONNECT: Starting register_connection with URL prefix: {db_url[:50]}..."
+    )
 
     # Parse JSON format if coming from AWS Secrets Manager
     parsed_url = _parse_json_database_url(db_url)

--- a/backend/open_webui/migrations/versions/242a2047eae0_update_chat_table.py
+++ b/backend/open_webui/migrations/versions/242a2047eae0_update_chat_table.py
@@ -62,7 +62,9 @@ def upgrade():
                     # Convert text JSON to actual JSON object, assuming the text is in JSON format
                     json_data = json.loads(row.old_chat)
                 except json.JSONDecodeError:
-                    json_data = None  # Handle cases where the text cannot be converted to JSON
+                    json_data = (
+                        None  # Handle cases where the text cannot be converted to JSON
+                    )
 
                 connection.execute(
                     sa.update(chat_table)

--- a/backend/open_webui/migrations/versions/3781e22d8b01_update_message_table.py
+++ b/backend/open_webui/migrations/versions/3781e22d8b01_update_message_table.py
@@ -20,8 +20,16 @@ def upgrade():
     conn = op.get_bind()
     inspector = inspect(conn)
     existing_tables = set(inspector.get_table_names())
-    channel_columns = {col["name"] for col in inspector.get_columns("channel")} if "channel" in existing_tables else set()
-    message_columns = {col["name"] for col in inspector.get_columns("message")} if "message" in existing_tables else set()
+    channel_columns = (
+        {col["name"] for col in inspector.get_columns("channel")}
+        if "channel" in existing_tables
+        else set()
+    )
+    message_columns = (
+        {col["name"] for col in inspector.get_columns("message")}
+        if "message" in existing_tables
+        else set()
+    )
 
     # Add 'type' column to the 'channel' table
     if "type" not in channel_columns:

--- a/backend/open_webui/migrations/versions/922e7a387820_add_group_table.py
+++ b/backend/open_webui/migrations/versions/922e7a387820_add_group_table.py
@@ -37,10 +37,26 @@ def upgrade():
         )
 
     # Get existing columns for each table
-    model_columns = {col["name"] for col in inspector.get_columns("model")} if "model" in existing_tables else set()
-    knowledge_columns = {col["name"] for col in inspector.get_columns("knowledge")} if "knowledge" in existing_tables else set()
-    prompt_columns = {col["name"] for col in inspector.get_columns("prompt")} if "prompt" in existing_tables else set()
-    tool_columns = {col["name"] for col in inspector.get_columns("tool")} if "tool" in existing_tables else set()
+    model_columns = (
+        {col["name"] for col in inspector.get_columns("model")}
+        if "model" in existing_tables
+        else set()
+    )
+    knowledge_columns = (
+        {col["name"] for col in inspector.get_columns("knowledge")}
+        if "knowledge" in existing_tables
+        else set()
+    )
+    prompt_columns = (
+        {col["name"] for col in inspector.get_columns("prompt")}
+        if "prompt" in existing_tables
+        else set()
+    )
+    tool_columns = (
+        {col["name"] for col in inspector.get_columns("tool")}
+        if "tool" in existing_tables
+        else set()
+    )
 
     # Add 'access_control' column to 'model' table
     if "access_control" not in model_columns:

--- a/backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py
+++ b/backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py
@@ -20,7 +20,11 @@ def upgrade():
     conn = op.get_bind()
     inspector = inspect(conn)
     existing_tables = set(inspector.get_table_names())
-    chat_columns = {col["name"] for col in inspector.get_columns("chat")} if "chat" in existing_tables else set()
+    chat_columns = (
+        {col["name"] for col in inspector.get_columns("chat")}
+        if "chat" in existing_tables
+        else set()
+    )
 
     if "folder" not in existing_tables:
         op.create_table(
@@ -33,7 +37,10 @@ def upgrade():
             sa.Column("meta", sa.JSON(), nullable=True),
             sa.Column("is_expanded", sa.Boolean(), default=False, nullable=False),
             sa.Column(
-                "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+                "created_at",
+                sa.DateTime(),
+                server_default=sa.func.now(),
+                nullable=False,
             ),
             sa.Column(
                 "updated_at",

--- a/backend/open_webui/migrations/versions/ca81bd47c050_add_config_table.py
+++ b/backend/open_webui/migrations/versions/ca81bd47c050_add_config_table.py
@@ -31,7 +31,10 @@ def upgrade():
             sa.Column("data", sa.JSON(), nullable=False),
             sa.Column("version", sa.Integer, nullable=False),
             sa.Column(
-                "created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
             ),
             sa.Column(
                 "updated_at",

--- a/backend/open_webui/migrations/versions/d1e2f3a4b5c6_add_billing_enrollment_fields.py
+++ b/backend/open_webui/migrations/versions/d1e2f3a4b5c6_add_billing_enrollment_fields.py
@@ -5,6 +5,7 @@ Revises: c4a3b2d1e0f
 Create Date: 2025-12-24 12:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op
@@ -13,8 +14,8 @@ from sqlalchemy import inspect
 
 
 # revision identifiers, used by Alembic.
-revision: str = 'd1e2f3a4b5c6'
-down_revision: Union[str, None] = 'c4a3b2d1e0f'
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, None] = "c4a3b2d1e0f"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -35,15 +36,25 @@ def upgrade() -> None:
         user_indexes = {idx["name"] for idx in inspector.get_indexes("user")}
 
     # Add billing enrollment fields to user table (idempotent)
-    with op.batch_alter_table('user', schema=None) as batch_op:
-        if 'email_hmac' not in user_columns:
-            batch_op.add_column(sa.Column('email_hmac', sa.String(length=255), nullable=True))
-        if 'billing_customer_id' not in user_columns:
-            batch_op.add_column(sa.Column('billing_customer_id', sa.String(length=255), nullable=True))
-        if 'ix_user_email_hmac' not in user_indexes:
-            batch_op.create_index(batch_op.f('ix_user_email_hmac'), ['email_hmac'], unique=False)
-        if 'ix_user_billing_customer_id' not in user_indexes:
-            batch_op.create_index(batch_op.f('ix_user_billing_customer_id'), ['billing_customer_id'], unique=True)
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        if "email_hmac" not in user_columns:
+            batch_op.add_column(
+                sa.Column("email_hmac", sa.String(length=255), nullable=True)
+            )
+        if "billing_customer_id" not in user_columns:
+            batch_op.add_column(
+                sa.Column("billing_customer_id", sa.String(length=255), nullable=True)
+            )
+        if "ix_user_email_hmac" not in user_indexes:
+            batch_op.create_index(
+                batch_op.f("ix_user_email_hmac"), ["email_hmac"], unique=False
+            )
+        if "ix_user_billing_customer_id" not in user_indexes:
+            batch_op.create_index(
+                batch_op.f("ix_user_billing_customer_id"),
+                ["billing_customer_id"],
+                unique=True,
+            )
 
     # Check existing columns in auth table
     auth_columns = set()
@@ -51,18 +62,20 @@ def upgrade() -> None:
         auth_columns = {col["name"] for col in inspector.get_columns("auth")}
 
     # Add email_hmac to auth table (idempotent)
-    with op.batch_alter_table('auth', schema=None) as batch_op:
-        if 'email_hmac' not in auth_columns:
-            batch_op.add_column(sa.Column('email_hmac', sa.String(length=255), nullable=True))
+    with op.batch_alter_table("auth", schema=None) as batch_op:
+        if "email_hmac" not in auth_columns:
+            batch_op.add_column(
+                sa.Column("email_hmac", sa.String(length=255), nullable=True)
+            )
 
 
 def downgrade() -> None:
     # Remove billing enrollment fields
-    with op.batch_alter_table('auth', schema=None) as batch_op:
-        batch_op.drop_column('email_hmac')
+    with op.batch_alter_table("auth", schema=None) as batch_op:
+        batch_op.drop_column("email_hmac")
 
-    with op.batch_alter_table('user', schema=None) as batch_op:
-        batch_op.drop_index(batch_op.f('ix_user_billing_customer_id'))
-        batch_op.drop_index(batch_op.f('ix_user_email_hmac'))
-        batch_op.drop_column('billing_customer_id')
-        batch_op.drop_column('email_hmac')
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_user_billing_customer_id"))
+        batch_op.drop_index(batch_op.f("ix_user_email_hmac"))
+        batch_op.drop_column("billing_customer_id")
+        batch_op.drop_column("email_hmac")

--- a/backend/open_webui/models/auths.py
+++ b/backend/open_webui/models/auths.py
@@ -30,9 +30,15 @@ class Auth(Base):
     # The 'id' of the Auth record now corresponds to the derived UserID from the User table.
     id = Column(String, primary_key=True)
 
-    email = Column(String, nullable=True)  # NOW NULLABLE (unused for billing-enrolled users)
-    email_hmac = Column(String(255), nullable=True)  # HMAC of email (for billing enrollment)
-    password = Column(Text, nullable=True)  # NOW NULLABLE (billing-enrolled users have NULL password)
+    email = Column(
+        String, nullable=True
+    )  # NOW NULLABLE (unused for billing-enrolled users)
+    email_hmac = Column(
+        String(255), nullable=True
+    )  # HMAC of email (for billing enrollment)
+    password = Column(
+        Text, nullable=True
+    )  # NOW NULLABLE (billing-enrolled users have NULL password)
     active = Column(Boolean)
 
 
@@ -40,7 +46,9 @@ class AuthModel(BaseModel):
     id: str  # Corresponds to UserID
     email: Optional[str] = None  # NOW OPTIONAL (for billing-enrolled users)
     email_hmac: Optional[str] = None  # HMAC of email (for billing enrollment)
-    password: Optional[str] = None  # NOW OPTIONAL (billing-enrolled users have NULL password)
+    password: Optional[str] = (
+        None  # NOW OPTIONAL (billing-enrolled users have NULL password)
+    )
     active: bool = True
 
 
@@ -107,6 +115,7 @@ class AddUserForm(SignupForm):
 
 class AddByTPAIHmacForm(BaseModel):
     """Form for billing enrollment endpoint (called by consumer Lambda)"""
+
     user_id: str  # email_hmac (also user.id)
     email_hmac: str  # must match user_id
     password: None  # must be None
@@ -117,6 +126,7 @@ class AddByTPAIHmacForm(BaseModel):
 
 class AddByTPAIHmacResponse(BaseModel):
     """Response for billing enrollment endpoint"""
+
     id: str
     email_hmac: str
     billing_customer_id: str
@@ -253,13 +263,19 @@ class AuthsTable:
             # Check if user already exists by email_hmac
             existing_user_by_hmac = Users.get_user_by_email_hmac(email_hmac)
             if existing_user_by_hmac:
-                log.info(f"User with email_hmac {email_hmac} already exists (idempotent)")
+                log.info(
+                    f"User with email_hmac {email_hmac} already exists (idempotent)"
+                )
                 return existing_user_by_hmac
 
             # Check if user already exists by billing_customer_id
-            existing_user_by_billing = Users.get_user_by_billing_customer_id(billing_customer_id)
+            existing_user_by_billing = Users.get_user_by_billing_customer_id(
+                billing_customer_id
+            )
             if existing_user_by_billing:
-                log.info(f"User with billing_customer_id {billing_customer_id} already exists (idempotent)")
+                log.info(
+                    f"User with billing_customer_id {billing_customer_id} already exists (idempotent)"
+                )
                 return existing_user_by_billing
 
             # Create Auth record with NULL password
@@ -279,7 +295,9 @@ class AuthsTable:
             salt_val = encryption_utils.generate_salt()
             user_key_val = encryption_utils.derive_key_from_user_id(user_id, salt_val)
             dek_plaintext = encryption_utils.generate_dek()
-            user_encrypted_dek_val = encryption_utils.encrypt_dek(dek_plaintext, user_key_val)
+            user_encrypted_dek_val = encryption_utils.encrypt_dek(
+                dek_plaintext, user_key_val
+            )
 
             # Create User record
             user = Users.insert_new_user(
@@ -303,7 +321,9 @@ class AuthsTable:
                 db.commit()
                 return user
             else:
-                log.error(f"Billing-enrolled user creation failed for {user_id}. Rolling back.")
+                log.error(
+                    f"Billing-enrolled user creation failed for {user_id}. Rolling back."
+                )
                 db.rollback()
                 return None
 

--- a/backend/open_webui/models/db_encryption_shim.py
+++ b/backend/open_webui/models/db_encryption_shim.py
@@ -68,7 +68,9 @@ def _set_dek_for_chat_operation(user_id: str, db_session: Session):
             f"Successfully set plaintext DEK in context for user {user_id} for chat operation."
         )
     except Exception as e:
-        log.warning(f"Failed to decrypt DEK for user {user_id}: {e}. Content stored as plaintext.")
+        log.warning(
+            f"Failed to decrypt DEK for user {user_id}: {e}. Content stored as plaintext."
+        )
         encryption_utils.current_user_dek_context.set(None)
 
 
@@ -112,9 +114,7 @@ def _traverse_and_encrypt(chat_obj: Chat):
 
     # This handles the nested history structure.
     history = chat_obj.chat.get("history", {})
-    history_messages = (
-        history.get("messages", {}) if isinstance(history, dict) else {}
-    )
+    history_messages = history.get("messages", {}) if isinstance(history, dict) else {}
 
     if isinstance(history_messages, dict):
         for msg_id, message in history_messages.items():
@@ -160,7 +160,9 @@ def _traverse_and_decrypt(chat_obj: Chat):
                     # equal the original plaintext content.
                     if plaintext == ciphertext and ciphertext:
                         # decrypt_message returned original data (silent failure)
-                        log.error("DECRYPTION FAILED for chat message: returned original ciphertext")
+                        log.error(
+                            "DECRYPTION FAILED for chat message: returned original ciphertext"
+                        )
                         # Preserve the encrypted dict as-is
                     else:
                         message["content"] = plaintext
@@ -187,7 +189,9 @@ def _traverse_and_decrypt(chat_obj: Chat):
                     plaintext = encryption_utils.decrypt_message(ciphertext)
                     # See comment above: Fernet ciphertext never equals plaintext
                     if plaintext == ciphertext and ciphertext:
-                        log.error(f"DECRYPTION FAILED for history message {msg_id}: returned original ciphertext")
+                        log.error(
+                            f"DECRYPTION FAILED for history message {msg_id}: returned original ciphertext"
+                        )
                         # Preserve the encrypted dict as-is
                     else:
                         message["content"] = plaintext

--- a/backend/open_webui/models/users.py
+++ b/backend/open_webui/models/users.py
@@ -27,8 +27,12 @@ class User(Base):
     # WRONG - I will ultimately no use this for SaaS; may be used for Enterprise
     # NOW NULLABLE to support billing-enrolled users (who have email_hmac instead)
     email = Column(String, unique=True, index=True, nullable=True)
-    email_hmac = Column(String(255), nullable=True, index=True)  # HMAC of email (for billing enrollment)
-    billing_customer_id = Column(String(255), nullable=True, unique=True, index=True)  # Stripe customer ID
+    email_hmac = Column(
+        String(255), nullable=True, index=True
+    )  # HMAC of email (for billing enrollment)
+    billing_customer_id = Column(
+        String(255), nullable=True, unique=True, index=True
+    )  # Stripe customer ID
     role = Column(String)
     profile_image_url = Column(Text)
 
@@ -249,11 +253,17 @@ class UsersTable:
         except Exception:
             return None
 
-    def get_user_by_billing_customer_id(self, billing_customer_id: str) -> Optional[UserModel]:
+    def get_user_by_billing_customer_id(
+        self, billing_customer_id: str
+    ) -> Optional[UserModel]:
         """Retrieve user by Stripe billing customer ID"""
         try:
             with get_db() as db:
-                user = db.query(User).filter_by(billing_customer_id=billing_customer_id).first()
+                user = (
+                    db.query(User)
+                    .filter_by(billing_customer_id=billing_customer_id)
+                    .first()
+                )
                 return UserModel.model_validate(user) if user else None
         except Exception:
             return None

--- a/backend/open_webui/routers/auths.py
+++ b/backend/open_webui/routers/auths.py
@@ -776,8 +776,7 @@ async def add_user(form_data: AddUserForm, user=Depends(get_admin_user)):
 
 @router.post("/add-by-tpai-hmac", response_model=AddByTPAIHmacResponse)
 async def add_user_by_tpai_hmac(
-    form_data: AddByTPAIHmacForm,
-    user=Depends(get_admin_user)
+    form_data: AddByTPAIHmacForm, user=Depends(get_admin_user)
 ):
     """
     Billing enrollment endpoint (called by consumer Lambda).
@@ -795,26 +794,30 @@ async def add_user_by_tpai_hmac(
     # Check idempotency (user exists?)
     existing_user_by_hmac = Users.get_user_by_email_hmac(form_data.email_hmac)
     if existing_user_by_hmac:
-        log.info(f"User with email_hmac {form_data.email_hmac} already exists (idempotent)")
+        log.info(
+            f"User with email_hmac {form_data.email_hmac} already exists (idempotent)"
+        )
         return AddByTPAIHmacResponse(
             id=existing_user_by_hmac.id,
             email_hmac=existing_user_by_hmac.email_hmac,
             billing_customer_id=existing_user_by_hmac.billing_customer_id,
             role=existing_user_by_hmac.role,
-            message="User already exists (idempotent success)"
+            message="User already exists (idempotent success)",
         )
 
     existing_user_by_billing = Users.get_user_by_billing_customer_id(
         form_data.billing_customer_id
     )
     if existing_user_by_billing:
-        log.info(f"User with billing_customer_id {form_data.billing_customer_id} already exists (idempotent)")
+        log.info(
+            f"User with billing_customer_id {form_data.billing_customer_id} already exists (idempotent)"
+        )
         return AddByTPAIHmacResponse(
             id=existing_user_by_billing.id,
             email_hmac=existing_user_by_billing.email_hmac,
             billing_customer_id=existing_user_by_billing.billing_customer_id,
             role=existing_user_by_billing.role,
-            message="User already exists (idempotent success)"
+            message="User already exists (idempotent success)",
         )
 
     # Create new user
@@ -834,7 +837,7 @@ async def add_user_by_tpai_hmac(
                 email_hmac=user.email_hmac,
                 billing_customer_id=user.billing_customer_id,
                 role=user.role,
-                message="User created successfully"
+                message="User created successfully",
             )
         else:
             raise HTTPException(500, detail=ERROR_MESSAGES.CREATE_USER_ERROR)

--- a/backend/open_webui/test/apps/webui/routers/test_encryption_e2e.py
+++ b/backend/open_webui/test/apps/webui/routers/test_encryption_e2e.py
@@ -144,7 +144,9 @@ class TestEncryptionE2E(AbstractPostgresTest):
         raw_messages = raw_chat.get("messages", [])
         assert len(raw_messages) == 1
         content_at_rest = raw_messages[0]["content"]
-        assert isinstance(content_at_rest, dict), "Content at rest should be an encrypted dict"
+        assert isinstance(
+            content_at_rest, dict
+        ), "Content at rest should be an encrypted dict"
         assert content_at_rest.get("is_encrypted") is True
         assert "ciphertext" in content_at_rest
         assert content_at_rest["ciphertext"] != "Hello encrypted world"
@@ -217,8 +219,14 @@ class TestEncryptionE2E(AbstractPostgresTest):
         # Both read back correctly via ORM
         from open_webui.models.chats import Chats
 
-        assert Chats.get_chat_by_id(enc_chat_id).chat["messages"][0]["content"] == "secret message"
-        assert Chats.get_chat_by_id(plain_chat_id).chat["messages"][0]["content"] == "open message"
+        assert (
+            Chats.get_chat_by_id(enc_chat_id).chat["messages"][0]["content"]
+            == "secret message"
+        )
+        assert (
+            Chats.get_chat_by_id(plain_chat_id).chat["messages"][0]["content"]
+            == "open message"
+        )
 
     def test_cross_user_dek_isolation(self):
         """User B's DEK cannot decrypt user A's ciphertext."""
@@ -244,7 +252,10 @@ class TestEncryptionE2E(AbstractPostgresTest):
         ciphertext = raw_chat["messages"][0]["content"]["ciphertext"]
 
         # Decrypt user B's DEK
-        from open_webui.utils.encryption_utils import decrypt_dek, current_user_dek_context
+        from open_webui.utils.encryption_utils import (
+            decrypt_dek,
+            current_user_dek_context,
+        )
         import base64
 
         dek_b = decrypt_dek(user_b.user_encrypted_dek, user_b.user_key)
@@ -283,7 +294,10 @@ class TestEncryptionE2E(AbstractPostgresTest):
         from open_webui.internal.db import get_db
         from sqlalchemy import text
 
-        corrupted_content = {"ciphertext": "AAAA-corrupted-garbage", "is_encrypted": True}
+        corrupted_content = {
+            "ciphertext": "AAAA-corrupted-garbage",
+            "is_encrypted": True,
+        }
         corrupted_chat = dict(raw_chat)
         corrupted_chat["messages"] = [{"role": "user", "content": corrupted_content}]
 
@@ -340,15 +354,19 @@ class TestEncryptionE2E(AbstractPostgresTest):
         raw_after = self._get_raw_chat_json(chat_id)
         assert raw_after["messages"][0]["content"]["is_encrypted"] is True
         ciphertext_after = raw_after["messages"][0]["content"]["ciphertext"]
-        assert ciphertext_after != ciphertext_before, "Ciphertext should change after update"
+        assert (
+            ciphertext_after != ciphertext_before
+        ), "Ciphertext should change after update"
 
         # ORM read: should return updated plaintext
         loaded = Chats.get_chat_by_id(chat_id)
         assert loaded.chat["messages"][0]["content"] == "updated message"
 
-    @pytest.mark.skip(reason="mock_webui_user creates a bare User without encryption keys; "
-                             "after_load hook cannot decrypt the response. Needs mock user "
-                             "with user_key/user_encrypted_dek to test API decryption path.")
+    @pytest.mark.skip(
+        reason="mock_webui_user creates a bare User without encryption keys; "
+        "after_load hook cannot decrypt the response. Needs mock user "
+        "with user_key/user_encrypted_dek to test API decryption path."
+    )
     def test_api_roundtrip_encrypted_chat(self):
         """Full FastAPI path: POST/GET returns plaintext while DB has ciphertext."""
         uid = str(uuid.uuid4())
@@ -434,7 +452,10 @@ class TestEncryptionE2E(AbstractPostgresTest):
             billing_id=f"billing-{uid_b}",
         )
 
-        from open_webui.utils.encryption_utils import decrypt_dek, current_user_dek_context
+        from open_webui.utils.encryption_utils import (
+            decrypt_dek,
+            current_user_dek_context,
+        )
 
         dek_a = decrypt_dek(user_a.user_encrypted_dek, user_a.user_key)
         dek_b = decrypt_dek(user_b.user_encrypted_dek, user_b.user_key)
@@ -620,11 +641,13 @@ class TestEncryptionE2E(AbstractPostgresTest):
 
         chat = Chats.insert_new_chat(
             user.id,
-            ChatForm(chat={
-                "title": "My Secret Title",
-                "name": "test",
-                "messages": [{"role": "user", "content": "some content"}],
-            }),
+            ChatForm(
+                chat={
+                    "title": "My Secret Title",
+                    "name": "test",
+                    "messages": [{"role": "user", "content": "some content"}],
+                }
+            ),
         )
         assert chat is not None
 

--- a/backend/open_webui/test/util/abstract_integration_test.py
+++ b/backend/open_webui/test/util/abstract_integration_test.py
@@ -71,7 +71,9 @@ class AbstractPostgresTest(AbstractIntegrationTest):
     @classmethod
     def setup_class(cls):
         super().setup_class()
-        cls.DOCKER_CONTAINER_NAME = f"postgres-test-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        cls.DOCKER_CONTAINER_NAME = (
+            f"postgres-test-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+        )
         try:
             env_vars_postgres = {
                 "POSTGRES_USER": "user",
@@ -93,7 +95,9 @@ class AbstractPostgresTest(AbstractIntegrationTest):
 
             def _cleanup():
                 try:
-                    cls.docker_client.containers.get(cls.DOCKER_CONTAINER_NAME).remove(force=True)
+                    cls.docker_client.containers.get(cls.DOCKER_CONTAINER_NAME).remove(
+                        force=True
+                    )
                 except Exception:
                     pass  # Already removed by teardown_class
 
@@ -159,7 +163,9 @@ class AbstractPostgresTest(AbstractIntegrationTest):
         Session.commit()
 
         # Dynamic table truncation — handles new tables automatically
-        result = Session.execute(text("SELECT tablename FROM pg_tables WHERE schemaname='public'"))
+        result = Session.execute(
+            text("SELECT tablename FROM pg_tables WHERE schemaname='public'")
+        )
         tables = [row[0] for row in result.fetchall()]
         for table in tables:
             Session.execute(text(f'TRUNCATE TABLE "{table}" CASCADE'))

--- a/backend/open_webui/utils/encryption_utils.py
+++ b/backend/open_webui/utils/encryption_utils.py
@@ -17,6 +17,7 @@ from cryptography.hazmat.backends import default_backend
 LOCAL_HMAC_KEY: bytes = os.environ.get("TPAI_LOCAL_HMAC_KEY", "").encode("utf-8")
 if not LOCAL_HMAC_KEY:
     import logging as _logging
+
     _logging.getLogger(__name__).warning(
         "TPAI_LOCAL_HMAC_KEY not set — user ID generation will fail until configured"
     )
@@ -387,8 +388,12 @@ if __name__ == "__main__":
     print("\nTesting no-DEK passthrough mode...")
     # Context is now clear, so get_key() returns None → passthrough
     passthrough_msg = "Message without encryption."
-    assert encrypt_message(passthrough_msg) == passthrough_msg, "No-DEK encrypt should passthrough"
-    assert decrypt_message(passthrough_msg) == passthrough_msg, "No-DEK decrypt should passthrough"
+    assert (
+        encrypt_message(passthrough_msg) == passthrough_msg
+    ), "No-DEK encrypt should passthrough"
+    assert (
+        decrypt_message(passthrough_msg) == passthrough_msg
+    ), "No-DEK decrypt should passthrough"
     print("No-DEK passthrough mode passed.")
 
     # Unit tests from previous step (for completeness of the __main__ block)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,7 +20,9 @@ try:
     import sqlalchemy  # noqa: F401
 except ImportError:
     for sa_mod in [
-        "sqlalchemy", "sqlalchemy.orm", "sqlalchemy.orm.attributes",
+        "sqlalchemy",
+        "sqlalchemy.orm",
+        "sqlalchemy.orm.attributes",
         "sqlalchemy.orm.session",
     ]:
         sys.modules[sa_mod] = MagicMock()

--- a/backend/tests/test_database_url_parser.py
+++ b/backend/tests/test_database_url_parser.py
@@ -43,7 +43,9 @@ class TestParseJsonDatabaseUrl:
 
     def test_json_missing_port_uses_default(self):
         """Missing port should default to 5432."""
-        json_url = '{"username":"user","password":"pass","host":"localhost","dbname":"db"}'
+        json_url = (
+            '{"username":"user","password":"pass","host":"localhost","dbname":"db"}'
+        )
         result = _parse_json_database_url(json_url)
         assert ":5432/" in result
 
@@ -61,7 +63,9 @@ class TestParseJsonDatabaseUrl:
 
     def test_json_missing_dbname_uses_default(self):
         """Missing dbname should default to postgres."""
-        json_url = '{"username":"user","password":"pass","host":"localhost","port":5432}'
+        json_url = (
+            '{"username":"user","password":"pass","host":"localhost","port":5432}'
+        )
         result = _parse_json_database_url(json_url)
         assert result.endswith("/postgres")
 
@@ -93,7 +97,9 @@ class TestParseJsonDatabaseUrl:
 
     def test_json_with_empty_credentials(self):
         """JSON with empty username/password should work."""
-        json_url = '{"username":"","password":"","host":"localhost","port":5432,"dbname":"db"}'
+        json_url = (
+            '{"username":"","password":"","host":"localhost","port":5432,"dbname":"db"}'
+        )
         result = _parse_json_database_url(json_url)
         assert result == "postgresql://:@localhost:5432/db"
 

--- a/backend/tests/test_db_encryption_shim.py
+++ b/backend/tests/test_db_encryption_shim.py
@@ -26,6 +26,7 @@ from open_webui.models.db_encryption_shim import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_chat_obj(messages=None, history_messages=None):
     """Create a mock Chat object with the given messages structure."""
     chat = {}
@@ -53,6 +54,7 @@ def _with_dek(fn):
 # Encrypt on flush
 # ---------------------------------------------------------------------------
 
+
 class TestTraverseAndEncrypt:
 
     def test_encrypts_plaintext_messages(self):
@@ -65,6 +67,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
 
         for msg in obj.chat["messages"]:
@@ -78,6 +81,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
 
         # Should be unchanged
@@ -112,6 +116,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
         # No exception — message is unchanged
         assert "content" not in obj.chat["messages"][0]
@@ -122,6 +127,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
         assert obj.chat["messages"][0]["content"] is None
 
@@ -130,6 +136,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
         assert obj.chat["messages"][0]["content"] == ""
 
@@ -142,6 +149,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
 
         msg = obj.chat["history"]["messages"]["msg-1"]
@@ -154,6 +162,7 @@ class TestTraverseAndEncrypt:
 
         def do():
             _traverse_and_encrypt(obj)
+
         _with_dek(do)
         assert "content" not in obj.chat["history"]["messages"]["msg-1"]
 
@@ -162,13 +171,12 @@ class TestTraverseAndEncrypt:
 # Decrypt on load
 # ---------------------------------------------------------------------------
 
+
 class TestTraverseAndDecrypt:
 
     def test_decrypts_encrypted_messages(self):
         """Round-trip: encrypt then decrypt should recover plaintext."""
-        obj = _make_chat_obj(
-            messages=[{"role": "user", "content": "Hello world"}]
-        )
+        obj = _make_chat_obj(messages=[{"role": "user", "content": "Hello world"}])
 
         dek = generate_dek()
         token = current_user_dek_context.set(dek)
@@ -190,7 +198,9 @@ class TestTraverseAndDecrypt:
     def test_preserves_ciphertext_on_decrypt_failure(self):
         """On decrypt failure, the encrypted dict is preserved (not replaced with error string)."""
         encrypted_dict = {"ciphertext": "invalid-ciphertext-data", "is_encrypted": True}
-        obj = _make_chat_obj(messages=[{"role": "user", "content": copy.deepcopy(encrypted_dict)}])
+        obj = _make_chat_obj(
+            messages=[{"role": "user", "content": copy.deepcopy(encrypted_dict)}]
+        )
 
         # Use a DEK that won't match the ciphertext
         dek = generate_dek()
@@ -209,7 +219,9 @@ class TestTraverseAndDecrypt:
     def test_history_preserves_ciphertext_on_failure(self):
         encrypted_dict = {"ciphertext": "bad-data", "is_encrypted": True}
         obj = _make_chat_obj(
-            history_messages={"msg-1": {"role": "user", "content": copy.deepcopy(encrypted_dict)}}
+            history_messages={
+                "msg-1": {"role": "user", "content": copy.deepcopy(encrypted_dict)}
+            }
         )
 
         dek = generate_dek()

--- a/backend/tests/test_encryption_utils.py
+++ b/backend/tests/test_encryption_utils.py
@@ -26,6 +26,7 @@ from open_webui.utils.encryption_utils import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_user_dek():
     """Generate a DEK and matching user key for tests."""
     dek = generate_dek()
@@ -38,6 +39,7 @@ def _make_user_dek():
 # ---------------------------------------------------------------------------
 # get_key / no-DEK passthrough
 # ---------------------------------------------------------------------------
+
 
 class TestGetKey:
     def test_returns_none_when_no_context(self):
@@ -74,6 +76,7 @@ class TestNoDekPassthrough:
 # PBKDF2 determinism
 # ---------------------------------------------------------------------------
 
+
 class TestDeriveKey:
     def test_deterministic(self):
         salt = generate_salt()
@@ -97,6 +100,7 @@ class TestDeriveKey:
 # DEK encrypt / decrypt round-trip
 # ---------------------------------------------------------------------------
 
+
 class TestDekRoundTrip:
     def test_round_trip(self):
         dek, user_key, encrypted_dek = _make_user_dek()
@@ -112,6 +116,7 @@ class TestDekRoundTrip:
 # ---------------------------------------------------------------------------
 # Message encrypt / decrypt with DEK
 # ---------------------------------------------------------------------------
+
 
 class TestMessageEncryption:
     def test_round_trip(self):
@@ -153,6 +158,7 @@ class TestMessageEncryption:
 # ---------------------------------------------------------------------------
 # generate_user_id
 # ---------------------------------------------------------------------------
+
 
 class TestGenerateUserId:
     def test_deterministic(self):


### PR DESCRIPTION
**Stacked on #9** (merge #9 first; this PR then retargets to `main`).

## Why the gate has been red

`Format Backend` has failed on `main` since 2026-03-16 (last green 2025-12-17). The workflow runs `pip install black` unpinned, so the gate checks the tree against whatever black released last week — the fork's tree is frozen at v0.6.15 + local commits and can never keep up. Every PR shows a red check unrelated to its contents, which trains everyone to ignore the gate.

Investigation detail: 3 of the 22 offending files (`main.py`, `routers/openai.py`, `utils/chat.py`) were offending **because of the over-long `[TPAI-DIAG]` lines** — #9 deletes those, fixing them as a side effect. This PR handles the remaining 19 (fork-local billing/encryption files + migrations).

## What this does

- Pins `black==25.12.0` in the workflow, with the bump policy in a comment (bump pin + reformat in the same commit).
- Reformats the 19 offending files with exactly that version. Formatting-only: quote normalization and line wrapping; every changed file passes `py_compile`; `black --check` is clean repo-wide afterwards.

## Merge order

#9 (S03 security sweep, red check is this pre-existing failure) → this PR → the Format Backend gate is green and meaningful for all future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)