### PR TITLE
feat: forward chat id in header (exact cherry-pick of upstream 671f577) — TPAI m1 Phase D

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -122,6 +122,7 @@ async def send_post_request(
     key: Optional[str] = None,
     content_type: Optional[str] = None,
     user: UserModel = None,
+    metadata: Optional[dict] = None,
 ):
 
     r = None
@@ -142,6 +143,11 @@ async def send_post_request(
                         "X-OpenWebUI-User-Id": user.id,
                         "X-OpenWebUI-User-Email": user.email,
                         "X-OpenWebUI-User-Role": user.role,
+                        **(
+                            {"X-OpenWebUI-Chat-Id": metadata.get("chat_id")}
+                            if metadata and metadata.get("chat_id")
+                            else {}
+                        ),
                     }
                     if ENABLE_FORWARD_USER_INFO_HEADERS and user
                     else {}
@@ -1343,6 +1349,7 @@ async def generate_chat_completion(
         key=get_api_key(url_idx, url, request.app.state.config.OLLAMA_API_CONFIGS),
         content_type="application/x-ndjson",
         user=user,
+        metadata=metadata,
     )
 
 
@@ -1381,6 +1388,8 @@ async def generate_openai_completion(
     url_idx: Optional[int] = None,
     user=Depends(get_verified_user),
 ):
+    metadata = form_data.pop("metadata", None)
+
     try:
         form_data = OpenAICompletionForm(**form_data)
     except Exception as e:
@@ -1446,6 +1455,7 @@ async def generate_openai_completion(
         stream=payload.get("stream", False),
         key=get_api_key(url_idx, url, request.app.state.config.OLLAMA_API_CONFIGS),
         user=user,
+        metadata=metadata,
     )
 
 
@@ -1527,6 +1537,7 @@ async def generate_openai_chat_completion(
         stream=payload.get("stream", False),
         key=get_api_key(url_idx, url, request.app.state.config.OLLAMA_API_CONFIGS),
         user=user,
+        metadata=metadata,
     )
 
 

--- a/backend/open_webui/routers/openai.py
+++ b/backend/open_webui/routers/openai.py
@@ -810,6 +810,11 @@ async def generate_chat_completion(
                 "X-OpenWebUI-User-Id": user.id,
                 "X-OpenWebUI-User-Email": user.email,
                 "X-OpenWebUI-User-Role": user.role,
+                **(
+                    {"X-OpenWebUI-Chat-Id": metadata.get("chat_id")}
+                    if metadata and metadata.get("chat_id")
+                    else {}
+                ),
             }
             if ENABLE_FORWARD_USER_INFO_HEADERS
             else {}


### PR DESCRIPTION
## What

Exact cherry-pick of upstream [`671f577`](https://github.com/open-webui/open-webui/commit/671f577264ed5bed6ec2c7cf97703b450a6ce2ec) ("feat/enh: forward chat id in header", first released upstream in v0.6.17) onto the fork. Adds `X-OpenWebUI-Chat-Id` to the forwarded user-info headers, gated by the existing `ENABLE_FORWARD_USER_INFO_HEADERS` flag (enabled in TPAITest since the S02 identity flip change-set).

## Why

TPAI external-content program, **m1 Phase D (decision D9)**: the gateway's trifecta taint rule scopes taint per **conversation**, keyed by this header. Plan: `plans/external-content/m1-substrate/plan.md` (Phase D); session S06 in `plans/external-content/SESSIONS.md`.

Per D9 this is deliberately **not** a submodule version bump (fork is v0.6.15 + local commits; a 626-commit merge is not worth a header) and the hunk is kept **byte-identical to upstream** so the eventual real bump merges clean.

## Verification

- `git cherry-pick 671f577` applied clean, no conflicts (upstream author preserved).
- Hunk-level diff comparison against upstream: `openai.py` and `ollama.py` hunks **byte-identical** to the upstream commit.
- `black==25.12.0 --check` (the CI pin): both files unchanged.
- `ast.parse` on both files: OK; all three `ollama.py` call sites have `metadata` in scope.
- Header only fires on genuine chat turns (`metadata.get("chat_id")` present); task/title generations omit it — the gateway falls back to session-keyed taint for those (gateway PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)